### PR TITLE
Make RSpec examples pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ doc
 # jeweler generated
 pkg
 
+# don't track Gemfile.lock in gem
+*.lock
+
 # Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore: 
 #
 # * Create a file at ~/.gitignore

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 # Add dependencies required to use your gem here.
 # Example:
 #   gem "activesupport", ">= 2.3.5"

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ source "https://rubygems.org"
 # Example:
 #   gem "activesupport", ">= 2.3.5"
 gemspec
+
+gem "anvl", :git => "git://github.com/uklibraries/anvl.git"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       namaste
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     anvl (0.3.0)
     checkm (0.1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,9 @@
+GIT
+  remote: git://github.com/uklibraries/anvl.git
+  revision: 285651d100482cb6204a7c3857057d2bf40c278d
+  specs:
+    anvl (0.3.0)
+
 PATH
   remote: .
   specs:
@@ -11,7 +17,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     ZenTest (4.9.3)
-    anvl (0.3.0)
     checkm (0.1.1)
     diff-lcs (1.1.3)
     i18n (0.6.0)
@@ -35,6 +40,7 @@ PLATFORMS
 
 DEPENDENCIES
   ZenTest
+  anvl!
   bundler
   dflat!
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    ZenTest (4.9.3)
     anvl (0.3.0)
     checkm (0.1.1)
     diff-lcs (1.1.3)
@@ -18,6 +19,7 @@ GEM
     namaste (0.3.0)
       i18n
     rake (0.9.2.2)
+    redgreen (1.2.2)
     rspec (2.11.0)
       rspec-core (~> 2.11.0)
       rspec-expectations (~> 2.11.0)
@@ -32,8 +34,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  ZenTest
   bundler
   dflat!
   rake
+  redgreen
   rspec
   yard

--- a/dflat.gemspec
+++ b/dflat.gemspec
@@ -6,6 +6,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Chris Beer"]
+  s.summary = %q{Ruby Dflat implementation}
   s.date = %q{2011-06-12}
   s.email = %q{chris@cbeer.info}
   s.extra_rdoc_files = [

--- a/dflat.gemspec
+++ b/dflat.gemspec
@@ -26,7 +26,9 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake"
   s.add_development_dependency "bundler"
+  s.add_development_dependency "redgreen"
   s.add_development_dependency "rspec"
   s.add_development_dependency 'yard'
+  s.add_development_dependency "ZenTest"
 end
 

--- a/lib/dflat/version.rb
+++ b/lib/dflat/version.rb
@@ -62,7 +62,7 @@ module Dflat
 
         manifest!
         lock
-        manifest.add dest, :base => data_path
+        manifest.add dest, :options => {:path => data_path}
         File.open(manifest_path, 'w') do |f|
           f.write(manifest.to_s)
         end
@@ -153,13 +153,13 @@ module Dflat
       def remove list, options = {}
         list = [list] if list.instance_of? String
         @redd.remove list.map { |x| x }, options
-        m = manifest!
+        manifest!
         list.each do |l|
-          m = m.remove l
+          manifest.remove l
         end
 
-        File.open(File.join(path, 'manifest.txt'), 'w') do |f|
-          f.write(m.to_s)
+        File.open(manifest_path, 'w') do |f|
+          f.write(manifest.to_s)
         end
       end
 

--- a/lib/dflat/version.rb
+++ b/lib/dflat/version.rb
@@ -62,9 +62,9 @@ module Dflat
 
         manifest!
         lock
-        m = manifest.add dest, :base => data_path
-        File.open(File.join(path, 'manifest.txt'), 'w') do |f|
-          f.write(m.to_s)
+        manifest.add dest, :base => data_path
+        File.open(manifest_path, 'w') do |f|
+          f.write(manifest.to_s)
         end
         
         unlock
@@ -75,14 +75,14 @@ module Dflat
         list = [list] if list.instance_of? String
         FileUtils.rm list.map { |x| File.join(data_path, x) }, options
 
-        m = manifest!
+        manifest!
         lock
         list.each do |l|
-          m = m.remove l
+          manifest.remove l
         end
 
-        File.open(File.join(path, 'manifest.txt'), 'w') do |f|
-          f.write(m.to_s)
+        File.open(manifest_path, 'w') do |f|
+          f.write(manifest.to_s)
         end
         unlock
       end
@@ -142,9 +142,9 @@ module Dflat
       def add source, dest, options = {}
         manifest!
         f = @redd.add source, dest, options
-        m = manifest.add dest, :base => File.join(data_path, 'add')
-        File.open(File.join(path, 'manifest.txt'), 'w') do |f|
-          f.write(m.to_s)
+        manifest.add dest, :options => {:path => File.join(data_path, 'add')}
+        File.open(manifest_path, 'w') do |f|
+          f.write(manifest.to_s)
         end
         
 	f

--- a/spec/dflat_spec.rb
+++ b/spec/dflat_spec.rb
@@ -43,7 +43,7 @@ describe "dflat" do
       file = @dflat.current.add 'LICENSE.txt', 'producer/abcdef'
       lines = @dflat.current.manifest!.to_s.split "\n"
       lines[0].should == '#%checkm_0.7'
-      lines[1].should =~ /provider\/abcdef/
+      lines[1].should =~ /producer\/abcdef/
       @dflat.current.manifest.should be_valid
     end
 


### PR DESCRIPTION
This pull request makes the current RSpec examples pass.  Problems fixed:
- Dflat::Version::Full#remove and Dflat::Version::Delta#remove treated Checkm::Manifest#remove as a chainable method, but that method returns an Array.
- The calls to Checkm::Manifest#add used `:base => foo_path` to specify base path, but Checkm::Manifest requires `:options => {:path => foo_path}` instead.
- One example had the typo "provider" for "producer".
- The gemspec was mildly invalid, and the Gemfile did not use HTTPS for the rubygems source.
